### PR TITLE
Resolve Active Bug and OpenTimeout

### DIFF
--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -14,13 +14,8 @@ class Server < ApplicationRecord
     end
   end
 
-  def update_and_save_history(current_stats)
-    self.server_histories.create current_stats
-  end
-  
   def active?
-    return false if @latest_stats.nil?
-    @latest_stats.active?
+    self.active
   end
 
   def get_stat(stat)

--- a/db/migrate/20180317032217_add_active_to_servers_remove_from_history.rb
+++ b/db/migrate/20180317032217_add_active_to_servers_remove_from_history.rb
@@ -1,0 +1,6 @@
+class AddActiveToServersRemoveFromHistory < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :server_histories, :active, :boolean
+    add_column :servers, :active, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171127172529) do
+ActiveRecord::Schema.define(version: 20180317032217) do
 
   create_table "server_histories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "server_id"
@@ -22,7 +22,6 @@ ActiveRecord::Schema.define(version: 20171127172529) do
     t.bigint   "free_ram"
     t.bigint   "cores_available"
     t.bigint   "current_core_usage"
-    t.boolean  "active"
     t.datetime "created_at",         null: false
     t.datetime "updated_at",         null: false
     t.integer  "usage_in_gb"
@@ -43,6 +42,7 @@ ActiveRecord::Schema.define(version: 20171127172529) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer  "port"
+    t.boolean  "active"
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|

--- a/spec/factories/servers.rb
+++ b/spec/factories/servers.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     current_ram_usage 2304305621
     free_ram 2000000000
     cores_available 2
-    active true
   end
   
   factory :server do
@@ -18,5 +17,6 @@ FactoryBot.define do
     sequence(:name) { |n| "Server #{n}" }
     hostname '127.0.0.1'
     port 3000
+    active true
   end
 end


### PR DESCRIPTION
Closes #9 

Does the following things:
- Moves the `active` attribute from `ServerHistory` and back to `Server` 
- Changes `active?` method in `Server` to reflect above change
- Removes method `save_and_update_history` from `Server`
- Adds additional `rescue` block to `QueryApiJob` for `OpenTimeout` exceptions
- Enhances logging in `QueryApiJob` to include more useful information